### PR TITLE
Diffs completely broken

### DIFF
--- a/VS.DiffAllFiles.VS2017/source.extension.vsixmanifest
+++ b/VS.DiffAllFiles.VS2017/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="8D0CE300-9898-128B-95F0-12C767EC20E3" Version="1.0.2" Language="en-US" Publisher="deadlydog" />
+        <Identity Id="8D0CE300-9898-128B-95F0-12C767EC20E3" Version="1.0.3" Language="en-US" Publisher="deadlydog" />
         <DisplayName>Diff All Files for VS2017</DisplayName>
         <Description xml:space="preserve">Quickly compare changes to all files in Git (staged/unstaged files or a commit) or TFS (shelveset, changeset, or with pending changes).</Description>
         <MoreInfo>https://github.com/deadlydog/VS.DiffAllFiles</MoreInfo>

--- a/VS.DiffAllFiles/GitHelper.cs
+++ b/VS.DiffAllFiles/GitHelper.cs
@@ -70,6 +70,9 @@ namespace VS_DiffAllFiles.StructuresAndEnums
 			var repoRootDirectory = repositoryPath.Replace(@".git\", string.Empty);
 			var relativeFilePath = filePathInRepository.Replace(repoRootDirectory, string.Empty);
 
+			// An update to LibGit2Sharp removed support for backslashes, so file paths must use forward slashes: https://github.com/libgit2/libgit2sharp/issues/1075
+			relativeFilePath = ReplaceBackslashesWithForwardSlashes(relativeFilePath);
+
 			// Connect to the Git repository.
 			using (var repository = GetGitRepository(repositoryPath))
 			{
@@ -120,6 +123,10 @@ namespace VS_DiffAllFiles.StructuresAndEnums
 			var repoRootDirectory = repositoryPath.Replace(@".git\", string.Empty);
 			var relativeFilePath = filePathInRepository.Replace(repoRootDirectory, string.Empty);
 			var previousVersionsRelativeFilePath = previousVersionsFilePathInRepository.Replace(repoRootDirectory, string.Empty);
+
+			// An update to LibGit2Sharp removed support for backslashes, so file paths must use forward slashes: https://github.com/libgit2/libgit2sharp/issues/1075
+			relativeFilePath = ReplaceBackslashesWithForwardSlashes(relativeFilePath);
+			previousVersionsRelativeFilePath = ReplaceBackslashesWithForwardSlashes(previousVersionsRelativeFilePath);
 
 			// Connect to the Git repository.
 			using (var repository = GetGitRepository(repositoryPath))
@@ -183,6 +190,9 @@ namespace VS_DiffAllFiles.StructuresAndEnums
 			var repoRootDirectory = repositoryPath.Replace(@".git\", string.Empty);
 			var relativeFilePath = filePathInRepository.Replace(repoRootDirectory, string.Empty);
 
+			// An update to LibGit2Sharp removed support for backslashes, so file paths must use forward slashes: https://github.com/libgit2/libgit2sharp/issues/1075
+			relativeFilePath = ReplaceBackslashesWithForwardSlashes(relativeFilePath);
+
 			// Connect to the Git repository.
 			using (var repository = GetGitRepository(repositoryPath))
 			{
@@ -209,5 +219,7 @@ namespace VS_DiffAllFiles.StructuresAndEnums
 				return repository.Config.ToList();
 			}
 		}
+
+		private static string ReplaceBackslashesWithForwardSlashes(string path) => path.Replace('\\', '/');
 	}
 }

--- a/VS.DiffAllFiles/GitHelper.cs
+++ b/VS.DiffAllFiles/GitHelper.cs
@@ -159,7 +159,8 @@ namespace VS_DiffAllFiles.StructuresAndEnums
 		private static Commit GetPreviousCommitOfFile(Repository repository, string filePathRelativeToRepository, string commitSha = null)
 		{
 			bool versionMatchesGivenVersion = false;
-			var fileHistory = repository.Commits.QueryBy(filePathRelativeToRepository);
+			// Need to use Topological sort to avoid "Given key not present in dictionary" error: https://github.com/libgit2/libgit2sharp/issues/1520
+			var fileHistory = repository.Commits.QueryBy(filePathRelativeToRepository, new CommitFilter { SortBy = CommitSortStrategies.Topological });
 			foreach (var version in fileHistory)
 			{
 				// If they want the latest commit or we have found the "previous" commit that they were after, return it.


### PR DESCRIPTION
fix: Use forward slashes for relative file paths to fix diffing. Issue #23 
fix: Use sorting to properly work around the "The given key not present in dictionary" error. #15 
Bump version number to 1.0.3 for new release.