### PR TITLE
Reenable async background loading

### DIFF
--- a/VS.DiffAllFiles.VS2019/source.extension.vsixmanifest
+++ b/VS.DiffAllFiles.VS2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="B4202C10-5715-1294-9DBA-15A319FF9EBF" Version="1.0.3" Language="en-US" Publisher="deadlydog" />
+        <Identity Id="B4202C10-5715-1294-9DBA-15A319FF9EBF" Version="1.0.4" Language="en-US" Publisher="deadlydog" />
         <DisplayName>Diff All Files for VS2019</DisplayName>
         <Description xml:space="preserve">Quickly compare changes to all files in Git (staged/unstaged files or a commit) or TFS (shelveset, changeset, or with pending changes).</Description>
         <MoreInfo>https://github.com/deadlydog/VS.DiffAllFiles</MoreInfo>

--- a/VS.DiffAllFiles/VS.DiffAllFilesPackage.cs
+++ b/VS.DiffAllFiles/VS.DiffAllFilesPackage.cs
@@ -34,7 +34,7 @@ namespace VS_DiffAllFiles
 #else
 	// Async Package info: https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-use-asyncpackage-to-load-vspackages-in-the-background?view=vs-2019
 	[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-	[ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.NoSolution, PackageAutoLoadFlags.None)]
+	[ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]
 	public abstract class VS_DiffAllFilesPackage : AsyncPackage
 #endif
 	{


### PR DESCRIPTION
Re-enable asynch background loading, even though it introduced an issue.

In VS 2019.1 synchronous extensions are disabled by default, so we are re-enabling async background loading on this extension, even though it will still cause issue https://github.com/deadlydog/VS.DiffAllFiles/issues/27.  See https://github.com/deadlydog/VS.DiffAllFiles/issues/32 for more details.